### PR TITLE
Fix bad reference to census_shapes.yml using RVM.

### DIFF
--- a/lib/census_api/request.rb
+++ b/lib/census_api/request.rb
@@ -60,7 +60,7 @@ module CensusApi
     def self.shapes
       return  @@census_shapes if defined?( @@census_shapes)
       @@census_shapes = {} 
-      YAML.load_file("lib/yml/census_shapes.yml").each{|k,v| @@census_shapes[k] = v}
+      YAML.load_file(File.dirname(__FILE__).to_s + '/../yml/census_shapes.yml').each{|k,v| @@census_shapes[k] = v}
       return @@census_shapes
     end
     


### PR DESCRIPTION
...This commit fixes the error _No such file or directory - lib/yml/census_shapes.yml_.

To repo the error:
- Start rails console
- Create an instance of CensusApis::Client  
  client = CensusApi::Client.new(CENSUS_API_KEY)
- Run command client.sf1('P0010001', 'STATE:06')

You will get "Errno::ENOENT: No such file or directory - lib/yml/census_shapes.yml"

The issue was the path was was trying to look into the project lib directory instead of the gem.
