### PR TITLE
Fix require statements to simplify use of gem

### DIFF
--- a/lib/census_api.rb
+++ b/lib/census_api.rb
@@ -1,3 +1,3 @@
-require 'rubygems'
-
-Dir["./lib/census_api/*"].each { |file| require file }
+require 'census_api/client'
+require 'census_api/request'
+require 'census_api/version'

--- a/lib/census_api/client.rb
+++ b/lib/census_api/client.rb
@@ -1,5 +1,7 @@
 module CensusApi
   class Client
+    require 'rest-client'
+
     attr_reader   :api_key, :options
     attr_accessor :dataset
 


### PR DESCRIPTION
When trying to use this gem, I had to explicitly require each file in the census_api folder.
